### PR TITLE
Handle absolute moves as well

### DIFF
--- a/svg2poly.ulp
+++ b/svg2poly.ulp
@@ -189,8 +189,6 @@ int svgcoords_to_coords(string s)
 
 /*
 *  Extract points from a given svg path.
-*  ASSUMES: User followed instructions on site
-*     File was saved as Plain SVG with Relative Moves
 */
 void extract_pts(string pts, string transform)
 {
@@ -198,7 +196,15 @@ void extract_pts(string pts, string transform)
 	int size = strsplit(svg_pts, pts, ' '),
 		new_pts = 0;
 	int i = 2;
-  int mode = 0;
+  int mode;
+
+  if(svg_pts[0] == "M"){
+    // Coords are Absolute
+    mode = 1;
+  }else{
+    // Coords are Relative
+    mode = 0;
+  }
 
 	// Path format:
 	//  m x,y x,y L X,Y l x,y .... z
@@ -211,18 +217,26 @@ void extract_pts(string pts, string transform)
   printf("%2d) %2.2f,%2.2f\n", num_polys, tmp_coords[0], tmp_coords[1]);
 
   while (i < size - 1){
-    if (svg_pts[i] == "m"){
-      // Next Coord is Absolute
-      // Coords are Offset
+    if (svg_pts[i] == "m" || svg_pts[i] == "M"){
+      if(svg_pts[i] == "M"){
+        // Coords are Absolute
+        mode = 1;
+      }else{
+        // Coords are Relative
+        mode = 0;
+      }
 
       svgcoords_to_coords(svg_pts[++i]);
 
-      pts_x[global_pts + new_pts] = tmp_coords[0];
-      pts_y[global_pts + new_pts] = tmp_coords[1];
+      if(mode == 0){
+        pts_x[global_pts + new_pts] += tmp_coords[0];
+        pts_y[global_pts + new_pts] += tmp_coords[1];
+      }else{
+        pts_x[global_pts + new_pts] = tmp_coords[0];
+        pts_y[global_pts + new_pts] = tmp_coords[1];
+      }
 
       new_pts++;
-
-      mode = 0;
     }else if (svg_pts[i] == "L"){
       // Coords are Absolute
       mode = 1;


### PR DESCRIPTION
After a bit of fiddling I've managed to make this script cope fine with the absolute move 'M' command in SVG, which my Inkscape seems to be keen on outputting. This fixes a problem that some polys end up offset in weird locations in the output
