### PR TITLE
Fixed vertical and horizontal line commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Inkscape_
 *   Repeat with all closed letters
 * Select all (w/ Node Cursor)
 * *Ctrl-Shift-K* (Break Apart)
+* Resize canvas with File > Document properties. Click "Resize to drawing or selection"
 * Save As > Plain SVG
 
 _Eagle_ 

--- a/svg2poly.ulp
+++ b/svg2poly.ulp
@@ -303,9 +303,6 @@ void extract_pts(string pts, string transform)
   if(svg_pts[0] == "M"){
     // Coords are Absolute
     mode = 1;
-
-    sprintf(svg_pts[1], "%s,%s", svg_pts[1], svg_pts[2]);
-
   }else{
     // Coords are Relative
     mode = 0;
@@ -332,7 +329,6 @@ void extract_pts(string pts, string transform)
 	  {
         // Coords are Absolute
         mode = 1;
-        sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
       }else{
         // Coords are Relative
         mode = 0;
@@ -385,16 +381,11 @@ void extract_pts(string pts, string transform)
 	// assume numerical coords if none of the above conditions are met
 	else
 	{
-	
-        if (mode == 1) 
-        {
-          sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
-        }
 	  
 	  // Line-to command, parse coordinates from text
 	  if ((mode == 0) || (mode == 1))
 	  {
-	    sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
+	    //sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
 		svgcoords_to_coords(svg_pts[i]);
 	  }
 	  

--- a/svg2poly.ulp
+++ b/svg2poly.ulp
@@ -291,7 +291,7 @@ void extract_pts(string pts, string transform)
 	{
 		scaleFactor = 1.0;
 	}
-	printf("Scale factor = %f\n",scaleFactor);
+	printf("SVG scale factor = %f\n",scaleFactor);
 	
 	string svg_pts[];
 	int size = strsplit(svg_pts, pts, ' '),
@@ -322,7 +322,10 @@ void extract_pts(string pts, string transform)
 
   printf("%2d) %2.2f,%2.2f\n", num_polys, tmp_coords[0], tmp_coords[1]);
   
-  while (i < size - 1){
+  while ((i < size - 1) && (svg_pts[i] != "z")){
+    tmp_coords[0] = 0;
+    tmp_coords[1] = 0;
+  
     if (svg_pts[i] == "m" || svg_pts[i] == "M")
 	{
       if(svg_pts[i] == "M")
@@ -335,7 +338,7 @@ void extract_pts(string pts, string transform)
         mode = 0;
       }
 	  
-		svgcoords_to_coords(svg_pts[++i]);
+      svgcoords_to_coords(svg_pts[++i]);
 
       if(mode == 0){
         pts_x[global_pts + new_pts] += tmp_coords[0] * scaleFactor;
@@ -343,7 +346,6 @@ void extract_pts(string pts, string transform)
       }else{
         pts_x[global_pts + new_pts] = tmp_coords[0] * scaleFactor;
         pts_y[global_pts + new_pts] = tmp_coords[1] * scaleFactor;
-        i++;
       }
 
       new_pts++;
@@ -383,15 +385,11 @@ void extract_pts(string pts, string transform)
 	// assume numerical coords if none of the above conditions are met
 	else
 	{
-	
-      if (mode == 1) 
-	  {
-        sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
-      }
 	  
 	  // Line-to command, parse coordinates from text
 	  if ((mode == 0) || (mode == 1))
 	  {
+	    sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
 		svgcoords_to_coords(svg_pts[i]);
 	  }
 	  

--- a/svg2poly.ulp
+++ b/svg2poly.ulp
@@ -385,6 +385,11 @@ void extract_pts(string pts, string transform)
 	// assume numerical coords if none of the above conditions are met
 	else
 	{
+	
+        if (mode == 1) 
+        {
+          sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]);
+        }
 	  
 	  // Line-to command, parse coordinates from text
 	  if ((mode == 0) || (mode == 1))


### PR DESCRIPTION
When the ULP encountered a 'h' or 'v' command, it would draw incorrectly. This was fixed by re-initiating tmp_coords[0] and tmp_coords[1] to zero at the beginning of the while loop.

I also removed the line:
   sprintf(svg_pts[i], "%s,%s", svg_pts[i], svg_pts[i+1]); 
from two places. this seems to be a patch for previous SVG formats that used a space instead of a comma for M x.xxx y.yyy
